### PR TITLE
Chore: [#120] Replace deprecated node:querystring with URLSearchParams

### DIFF
--- a/lib/confirmationCode.js
+++ b/lib/confirmationCode.js
@@ -1,5 +1,4 @@
 import http from 'node:http';
-import querystring from 'node:querystring';
 import readline from 'node:readline/promises';
 
 import { camelToSnakeObject } from './camelToSnake.js';
@@ -31,13 +30,13 @@ export function getConfirmationCodeUrl(clientID, clientOptions = {}) {
   return (
     YANDEX_OAUTH_VERIFICATION_URL +
     '?' +
-    querystring.stringify(
+    new URLSearchParams(
       camelToSnakeObject({
         clientID,
         responseType: 'code',
         ...clientOptions
       })
-    )
+    ).toString()
   );
 }
 

--- a/specs/confirmationCode.spec.js
+++ b/specs/confirmationCode.spec.js
@@ -29,7 +29,7 @@ describe('getConfirmationCodeUrl', () => {
         forceConfirm: true
       })
     ).toBe(
-      `${YANDEX_OAUTH_VERIFICATION_URL}?client_id=${CLIENT_ID}&response_type=code&device_id=my-laptop&device_name=My%20Super%20Duper%20Laptop&force_confirm=true`
+      `${YANDEX_OAUTH_VERIFICATION_URL}?client_id=${CLIENT_ID}&response_type=code&device_id=my-laptop&device_name=My+Super+Duper+Laptop&force_confirm=true`
     );
   });
 });


### PR DESCRIPTION
Replaces the last remaining `querystring` usage with the native `URLSearchParams` API.
- Replace `querystring.stringify` with `new URLSearchParams(...).toString()` in `getConfirmationCodeUrl`
- Update test expectation for space encoding (`%20` → `+`)

Closes #120