### PR TITLE
Chore: [#122] Remove dotenv and fix husky deprecation warnings

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged -r --no-stash

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm test

--- a/example.js
+++ b/example.js
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import * as dotenv from 'dotenv';
-dotenv.config();
 
 import { auth } from './index.js';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@eslint/js": "^10.0.1",
         "@eslint/markdown": "^8.0.2",
         "c8": "^11.0.0",
-        "dotenv": "^17.4.2",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
@@ -509,6 +508,7 @@
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
       "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "environment": "^1.0.0"
       },
@@ -616,6 +616,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
       },
@@ -631,6 +632,7 @@
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
       "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "slice-ansi": "^8.0.0",
         "string-width": "^8.2.0"
@@ -786,18 +788,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -809,6 +799,7 @@
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -898,6 +889,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -1044,7 +1036,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1251,6 +1244,7 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
       "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "husky": "bin.js"
       },
@@ -1293,6 +1287,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
       "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.3.1"
       },
@@ -1432,6 +1427,7 @@
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.7.tgz",
       "integrity": "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "listr2": "^10.2.1",
         "picomatch": "^4.0.4",
@@ -1456,6 +1452,7 @@
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
       "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cli-truncate": "^5.2.0",
         "eventemitter3": "^5.0.4",
@@ -1487,6 +1484,7 @@
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
       "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^7.0.0",
         "cli-cursor": "^5.0.0",
@@ -1506,6 +1504,7 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
       "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "is-fullwidth-code-point": "^5.0.0"
@@ -1522,6 +1521,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -1539,6 +1539,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "string-width": "^7.0.0",
@@ -3225,6 +3226,7 @@
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3268,6 +3270,22 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.3",
@@ -3356,6 +3374,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -3415,24 +3434,10 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "onetime": "^7.0.0",
         "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/onetime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-function": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -3445,7 +3450,8 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.2",
@@ -3498,6 +3504,7 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
       "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.3",
         "is-fullwidth-code-point": "^5.1.0"
@@ -3514,6 +3521,7 @@
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
       "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.19"
       }
@@ -3523,6 +3531,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
       "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
         "strip-ansi": "^7.1.2"
@@ -3599,6 +3608,7 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -3747,6 +3757,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
       "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.3",
         "string-width": "^8.2.0",
@@ -3774,6 +3785,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "bin": {
         "yaml": "bin.mjs"
@@ -4383,12 +4395,6 @@
       "requires": {
         "dequal": "^2.0.0"
       }
-    },
-    "dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "dev": true
     },
     "emoji-regex": {
       "version": "10.6.0",
@@ -6064,6 +6070,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "requires": {
+        "mimic-function": "^5.0.0"
+      }
+    },
     "optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -6159,17 +6174,6 @@
       "requires": {
         "onetime": "^7.0.0",
         "signal-exit": "^4.1.0"
-      },
-      "dependencies": {
-        "onetime": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-          "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-          "dev": true,
-          "requires": {
-            "mimic-function": "^5.0.0"
-          }
-        }
       }
     },
     "rfdc": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "npm run lint -- --fix",
     "lint:all": "npm run lint -- index.js lib/* specs/*",
     "lint:all:fix": "npm run lint:all -- --fix",
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "c8 --reporter=lcov --reporter=text --exclude='specs/__mocks__' node --test specs/*.spec.js",
     "test:watch": "node --test --watch specs/*.spec.js"
   },
@@ -36,7 +36,6 @@
     "@eslint/js": "^10.0.1",
     "@eslint/markdown": "^8.0.2",
     "c8": "^11.0.0",
-    "dotenv": "^17.4.2",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",

--- a/specs/auth.spec.js
+++ b/specs/auth.spec.js
@@ -1,6 +1,3 @@
-import * as dotenv from 'dotenv';
-dotenv.config();
-
 import http from 'node:http';
 import { beforeEach, afterEach, test, mock } from 'node:test';
 import assert from 'node:assert/strict';


### PR DESCRIPTION
Removes the `dotenv` dependency and fixes Husky v9 deprecation warnings.

- Remove `dotenv` — env vars provided by GitHub secrets in CI, local devs set via shell
- Remove `dotenv` imports from `example.js` and `auth.spec.js`
- Fix husky v9 deprecation: `"husky install"` → `"husky"` in `prepare` script
- Strip deprecated `_/husky.sh` boilerplate from hook files

Closes #122