### PR TITLE
Feat: [#133] Add CLI command to obtain Yandex OAuth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,38 @@
 # ya-token-cli [![NPM version](https://img.shields.io/npm/v/ya-token-cli.svg?style=flat-square)](https://www.npmjs.com/package/ya-token-cli) ![Tests](https://github.com/RomiC/ya-token-cli/workflows/Tests/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/RomiC/ya-token-cli/badge.svg?branch=main)](https://coveralls.io/github/RomiC/ya-token-cli?branch=main)
 
-This library contains some utilities to obtain Yandex OAuth token for CLI utilities. The process of [getting token](https://yandex.ru/dev/id/doc/en/codes/screen-code) consists of two steps:
+This library contains some utilities to obtain Yandex OAuth token — both as a library and as a CLI command.
+
+## CLI usage
+
+Run directly via `npx`:
+
+```sh
+npx ya-token-cli -i <client-id> -s <client-secret> -r http://localhost:8899
+```
+
+Or install globally:
+
+```sh
+npm i -g ya-token-cli
+ya-token-cli -i <client-id> -s <client-secret> -r http://localhost:8899
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `-i, --client-id <id>` | Yandex OAuth client ID |
+| `-s, --client-secret <secret>` | Yandex OAuth client secret |
+| `-r, --redirect-uri <uri>` | Redirect URI for automatic flow |
+| `-m, --manual` | Skip automatic redirect, prompt for code manually |
+| `-u, --short-url` | Shorten the auth URL using clck.ru |
+| `-h, --help` | Show help |
+
+Environment variables (`YANDEX_CLIENT_ID`, `YANDEX_CLIENT_SECRET`, `REDIRECT_URI`) are also supported as fallback.
+
+When run without arguments, the CLI prompts interactively for any missing values.
+
+## Library usage The process of [getting token](https://yandex.ru/dev/id/doc/en/codes/screen-code) consists of two steps:
 
 1. Obtain confirmation code.
 2. Exchange confirmation code to a token.

--- a/bin/ya-token-cli.js
+++ b/bin/ya-token-cli.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import readline from 'node:readline/promises';
+import { Command } from 'commander';
+import { auth } from '../index.js';
+
+/**
+ * Prompt user for input via stdin/stdout.
+ * Exported for testability.
+ * @param {import('node:readline/promises').Interface} rl - readline interface
+ * @param {string} question - prompt text
+ * @param {string} [defaultValue] - optional default value
+ * @returns {Promise<string>}
+ */
+export async function prompt(rl, question, defaultValue) {
+  const text = defaultValue ? `${question} (${defaultValue}): ` : `${question}: `;
+  const answer = await rl.question(text);
+  return answer.trim() || defaultValue || '';
+}
+
+/**
+ * Validate that a required value is present, exiting with an error if not.
+ * @param {string} value
+ * @param {string} label - human-readable label for the error message
+ * @returns {string}
+ */
+function requireValue(value, label) {
+  if (!value) {
+    console.error(
+      `Error: ${label} is required. Provide it via --${label.toLowerCase().replace(/ /g, '-')} flag or ${label.toUpperCase().replace(/ /g, '_')} environment variable.`
+    );
+    process.exit(1);
+  }
+  return value;
+}
+
+/**
+ * Main CLI logic.
+ * @param {string[]} [args] - command-line arguments (defaults to process.argv)
+ */
+export async function main(args = process.argv) {
+  const program = new Command();
+
+  program
+    .name('ya-token-cli')
+    .description('Obtain a Yandex OAuth token via interactive CLI')
+    .option('-i, --client-id <id>', 'Yandex OAuth client ID')
+    .option('-s, --client-secret <secret>', 'Yandex OAuth client secret')
+    .option('-r, --redirect-uri <uri>', 'Redirect URI for automatic flow')
+    .option('-m, --manual', 'Skip automatic redirect, prompt for code manually')
+    .option('-u, --short-url', 'Shorten the auth URL using clck.ru', false)
+    .exitOverride()
+    .showHelpAfterError();
+
+  try {
+    program.parse(args);
+  } catch (error) {
+    // Commander throws on --help (exitCode=0) or unknown options (exitCode=1)
+    process.exit(error.exitCode ?? 1);
+    return;
+  }
+
+  const opts = program.opts();
+
+  // Gather values: flag > env > interactive prompt
+  let clientId = opts.clientId || process.env.YANDEX_CLIENT_ID;
+  let clientSecret = opts.clientSecret || process.env.YANDEX_CLIENT_SECRET;
+  let redirectUri = opts.redirectUri || process.env.REDIRECT_URI;
+  const useManual = opts.manual || false;
+  const useShortUrl = opts.shortUrl || false;
+
+  // Interactive prompts for missing values
+  let obtainAutomatically = !useManual;
+
+  const needsPrompts =
+    !clientId ||
+    !clientSecret ||
+    (obtainAutomatically && !redirectUri) ||
+    (opts.manual === undefined && opts.redirectUri === undefined);
+
+  if (needsPrompts) {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+    try {
+      if (!clientId) {
+        clientId = await prompt(rl, 'Enter Yandex Client ID');
+      }
+
+      if (!clientSecret) {
+        clientSecret = await prompt(rl, 'Enter Yandex Client Secret');
+      }
+
+      // Only ask about mode if neither --manual nor --redirect-uri was explicitly provided
+      if (opts.manual === undefined && opts.redirectUri === undefined) {
+        const modeAnswer = await prompt(rl, 'Obtain token automatically via redirect?', 'Y');
+        obtainAutomatically = modeAnswer.toLowerCase() !== 'n';
+      }
+
+      if (obtainAutomatically && !redirectUri) {
+        redirectUri = await prompt(rl, 'Enter Redirect URI', 'http://localhost:8899');
+      }
+    } finally {
+      rl.close();
+    }
+  }
+
+  // Validate required values
+  clientId = requireValue(clientId, 'client-id');
+  clientSecret = requireValue(clientSecret, 'client-secret');
+
+  const clientOptions = {};
+  if (redirectUri) {
+    clientOptions.redirectURI = redirectUri;
+  }
+
+  try {
+    const tokenData = await auth(clientId, clientSecret, clientOptions, useShortUrl, obtainAutomatically);
+    console.log('\n=== Token obtained successfully ===');
+    console.log(tokenData);
+  } catch (error) {
+    console.error(`\nError: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+// Auto-run only when executed as the entry point
+// Resolve symlinks so global `npm i -g ./` symlinks still trigger the guard
+const entryPath = process.argv[1] ? realpathSync(process.argv[1]) : null;
+const modulePath = realpathSync(fileURLToPath(import.meta.url));
+if (entryPath === modulePath) {
+  main();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "ya-token-cli",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "commander": "^15.0.0"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@eslint/markdown": "^8.0.2",
@@ -693,6 +696,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -4331,6 +4343,11 @@
           }
         }
       }
+    },
+    "commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="
     },
     "convert-source-map": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,17 @@
   "description": "Library to obtain OAuth-token to get access to Yandex services for server application",
   "type": "module",
   "main": "index.js",
+"bin": {
+  "ya-token-cli": "./bin/ya-token-cli.js"
+},
   "scripts": {
     "lint": "eslint --max-warnings 0",
     "lint:fix": "npm run lint -- --fix",
-    "lint:all": "npm run lint -- index.js lib/* specs/*",
+    "lint:all": "npm run lint -- index.js lib/* bin/* specs/*",
     "lint:all:fix": "npm run lint:all -- --fix",
     "prepare": "husky",
-    "test": "c8 --reporter=lcov --reporter=text --exclude='specs/__mocks__' node --test specs/*.spec.js",
-    "test:watch": "node --test --watch specs/*.spec.js"
+    "test": "c8 --reporter=lcov --reporter=text --exclude='specs/__mocks__' node --test specs/*.spec.js bin/*.spec.js",
+    "test:watch": "node --test --watch specs/*.spec.js bin/*.spec.js"
   },
   "engines": {
     "node": ">=22"
@@ -48,12 +51,15 @@
     "yargs": "^18.0.0"
   },
   "lint-staged": {
-    "+(lib|specs)/*.js": "npm run lint:fix"
+    "+(lib|specs|bin)/*.js": "npm run lint:fix"
   },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged -r --no-stash",
       "pre-push": "npm test"
     }
+  },
+  "dependencies": {
+    "commander": "^15.0.0"
   }
 }

--- a/specs/cli.spec.js
+++ b/specs/cli.spec.js
@@ -1,0 +1,401 @@
+import http from 'node:http';
+import { beforeEach, afterEach, test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { useReadlineMock, readlineMock } from './__mocks__/readline.mock.js';
+import { useFetchMock, createFetchMock } from './__mocks__/fetch.mock.js';
+import { main } from '../bin/ya-token-cli.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+useReadlineMock();
+useFetchMock();
+
+beforeEach(() => {
+  mock.method(process, 'exit', () => {});
+  mock.method(process.stdout, 'write', () => {});
+  mock.method(process.stderr, 'write', () => {});
+  // Clear Yandex-related env vars for a clean slate
+  delete process.env.YANDEX_CLIENT_ID;
+  delete process.env.YANDEX_CLIENT_SECRET;
+  delete process.env.REDIRECT_URI;
+});
+
+afterEach(() => {
+  mock.restoreAll();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+// ---------------------------------------------------------------------------
+// main() — error handling (answers prompts with empty to trigger validation)
+// ---------------------------------------------------------------------------
+
+test('main() exits when client-id is missing', async () => {
+  process.env.YANDEX_CLIENT_SECRET = 'env-secret';
+
+  // Provide a fetch mock so auth() doesn't fail if it runs
+  createFetchMock({ body: { access_token: 'dummy' } });
+
+  const mainPromise = main(['node', 'bin/ya-token-cli.js', '--manual']);
+
+  // Prompt for client-id — answer empty to trigger validation
+  const q = readlineMock._lastInterface._lastQuestion;
+  assert.strictEqual(q._title, 'Enter Yandex Client ID: ');
+  q._answer('');
+
+  // Answer confirmation code prompt from auth() in manual mode
+  await new Promise(process.nextTick);
+  const codeQ = readlineMock._lastInterface._lastQuestion;
+  codeQ._answer('dummy');
+
+  await mainPromise;
+
+  // process.exit was called with error code for missing client-id
+  assert.strictEqual(process.exit.mock.callCount(), 1);
+  assert.strictEqual(process.exit.mock.calls[0].arguments[0], 1);
+
+  assert.ok(
+    process.stderr.write.mock.calls.some(
+      (call) => typeof call.arguments[0] === 'string' && call.arguments[0].includes('client-id is required')
+    )
+  );
+});
+
+test('main() exits when client-secret is missing', async () => {
+  process.env.YANDEX_CLIENT_ID = 'env-cid';
+
+  createFetchMock({ body: { access_token: 'dummy' } });
+
+  const mainPromise = main(['node', 'bin/ya-token-cli.js', '--manual']);
+
+  // Prompt for client-secret — answer empty
+  const q = readlineMock._lastInterface._lastQuestion;
+  assert.strictEqual(q._title, 'Enter Yandex Client Secret: ');
+  q._answer('');
+
+  // Answer confirmation code prompt from auth() in manual mode
+  await new Promise(process.nextTick);
+  const codeQ = readlineMock._lastInterface._lastQuestion;
+  codeQ._answer('dummy');
+
+  await mainPromise;
+
+  assert.strictEqual(process.exit.mock.callCount(), 1);
+  assert.strictEqual(process.exit.mock.calls[0].arguments[0], 1);
+
+  assert.ok(
+    process.stderr.write.mock.calls.some(
+      (call) => typeof call.arguments[0] === 'string' && call.arguments[0].includes('client-secret is required')
+    )
+  );
+});
+
+test('main() displays help with --help', async () => {
+  let helpOutput = '';
+  mock.method(process.stdout, 'write', (chunk) => {
+    helpOutput += chunk;
+  });
+
+  // Restore process.exit mock so --help can exit cleanly
+  // but continue watching for the actual exit call
+  const exitSpy = mock.fn(() => {});
+  process.exit = exitSpy;
+
+  await main(['node', 'bin/ya-token-cli.js', '--help']);
+
+  // process.exit(0) was called by commander via our wrapper
+  assert.strictEqual(exitSpy.mock.callCount(), 1);
+  assert.strictEqual(exitSpy.mock.calls[0].arguments[0], 0);
+
+  assert.ok(helpOutput.includes('ya-token-cli'));
+  assert.ok(helpOutput.includes('--client-id'));
+  assert.ok(helpOutput.includes('--client-secret'));
+  assert.ok(helpOutput.includes('--redirect-uri'));
+  assert.ok(helpOutput.includes('--manual'));
+  assert.ok(helpOutput.includes('--short-url'));
+  assert.ok(helpOutput.includes('--help'));
+});
+
+// ---------------------------------------------------------------------------
+// main() — successful auth via mocked fetch and readline
+// ---------------------------------------------------------------------------
+
+test('main() all flags manual mode with short URL', async () => {
+  const tokenData = {
+    access_token: 'test-token-manual',
+    expires_in: 3600,
+    refresh_token: 'test-refresh',
+    token_type: 'bearer'
+  };
+
+  createFetchMock({ body: 'https://clck.ru/manual' }); // clck.ru
+  createFetchMock({ body: tokenData }); // token exchange
+
+  const mainPromise = main([
+    'node',
+    'bin/ya-token-cli.js',
+    '--client-id',
+    'test-cid',
+    '--client-secret',
+    'test-csecret',
+    '--manual',
+    '--short-url'
+  ]);
+
+  // auth() calls readConfirmationCode() — answer the code prompt
+  await new Promise(process.nextTick);
+  const codeQuestion = readlineMock._lastInterface._lastQuestion;
+  assert.strictEqual(codeQuestion._title, 'Enter confirmation code: ');
+  codeQuestion._answer('123456');
+
+  await mainPromise;
+
+  assert.strictEqual(process.exit.mock.callCount(), 0); // success
+  assert.ok(fetch.mock.callCount() >= 1);
+  assert.ok(
+    process.stdout.write.mock.calls.some(
+      (call) => typeof call.arguments[0] === 'string' && call.arguments[0].includes('Token obtained successfully')
+    )
+  );
+});
+
+test('main() all flags automatic mode with redirect URI', async () => {
+  const tokenData = {
+    access_token: 'test-token-auto',
+    expires_in: 3600,
+    refresh_token: 'test-refresh',
+    token_type: 'bearer'
+  };
+
+  createFetchMock({ body: tokenData }); // token exchange (no clck.ru)
+
+  const mainPromise = main([
+    'node',
+    'bin/ya-token-cli.js',
+    '--client-id',
+    'auto-cid',
+    '--client-secret',
+    'auto-csecret',
+    '--redirect-uri',
+    'http://localhost:18888'
+  ]);
+
+  // Wait for the redirect server to start
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  // Simulate Yandex OAuth redirect
+  await new Promise((resolve, reject) => {
+    const req = http.request('http://localhost:18888/?code=654321', (response) => {
+      response.resume();
+      response.statusCode === 200 ? resolve() : reject(response.statusCode);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+
+  await mainPromise;
+
+  assert.strictEqual(process.exit.mock.callCount(), 0); // success
+  assert.ok(
+    process.stdout.write.mock.calls.some(
+      (call) => typeof call.arguments[0] === 'string' && call.arguments[0].includes('Token obtained successfully')
+    )
+  );
+});
+
+test('main() without --short-url suppresses clck.ru call (default off)', async () => {
+  const tokenData = { access_token: 'no-short', expires_in: 3600, token_type: 'bearer' };
+
+  createFetchMock({ body: tokenData }); // only token exchange
+
+  const mainPromise = main([
+    'node',
+    'bin/ya-token-cli.js',
+    '--client-id',
+    'cid',
+    '--client-secret',
+    'secret',
+    '--redirect-uri',
+    'http://localhost:18889'
+    // --short-url not passed = off by default
+  ]);
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  await new Promise((resolve, reject) => {
+    const req = http.request('http://localhost:18889/?code=111111', (response) => {
+      response.resume();
+      response.statusCode === 200 ? resolve() : reject(response.statusCode);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+
+  await mainPromise;
+
+  // Should only have one fetch call (token exchange), no clck.ru
+  assert.strictEqual(fetch.mock.callCount(), 1);
+});
+
+// ---------------------------------------------------------------------------
+// main() — env vars
+// ---------------------------------------------------------------------------
+
+test('main() uses env vars when flags are not provided', async () => {
+  process.env.YANDEX_CLIENT_ID = 'env-cid';
+  process.env.YANDEX_CLIENT_SECRET = 'env-csecret';
+  process.env.REDIRECT_URI = 'http://localhost:18890';
+
+  const tokenData = { access_token: 'env-token', expires_in: 3600, token_type: 'bearer' };
+  createFetchMock({ body: tokenData });
+
+  const mainPromise = main(['node', 'bin/ya-token-cli.js', '--manual']);
+
+  // auth() in manual mode asks for confirmation code
+  await new Promise(process.nextTick);
+  const codeQuestion = readlineMock._lastInterface._lastQuestion;
+  codeQuestion._answer('env-code');
+
+  await mainPromise;
+
+  assert.strictEqual(process.exit.mock.callCount(), 0); // success
+  assert.ok(
+    process.stdout.write.mock.calls.some(
+      (call) => typeof call.arguments[0] === 'string' && call.arguments[0].includes('Token obtained successfully')
+    )
+  );
+});
+
+test('main() flag overrides env var', async () => {
+  process.env.YANDEX_CLIENT_ID = 'env-cid';
+  process.env.YANDEX_CLIENT_SECRET = 'env-csecret';
+
+  const tokenData = { access_token: 'flag-wins', expires_in: 3600, token_type: 'bearer' };
+  createFetchMock({ body: tokenData });
+
+  const mainPromise = main([
+    'node',
+    'bin/ya-token-cli.js',
+    '--client-id',
+    'flag-cid',
+    '--redirect-uri',
+    'http://localhost:18891',
+    '--manual'
+  ]);
+
+  // auth() in manual mode asks for confirmation code
+  await new Promise(process.nextTick);
+  const codeQuestion = readlineMock._lastInterface._lastQuestion;
+  codeQuestion._answer('flag-code');
+
+  await mainPromise;
+
+  assert.strictEqual(process.exit.mock.callCount(), 0); // success
+});
+
+// ---------------------------------------------------------------------------
+// main() — interactive prompts
+// ---------------------------------------------------------------------------
+
+test('main() prompts for missing client-secret', async () => {
+  process.env.YANDEX_CLIENT_ID = 'env-cid';
+
+  const tokenData = { access_token: 'prompt-secret', expires_in: 3600, token_type: 'bearer' };
+  createFetchMock({ body: tokenData });
+
+  const mainPromise = main(['node', 'bin/ya-token-cli.js', '--manual']);
+
+  // Should prompt only for client-secret (client-id is in env)
+  const secretQuestion = readlineMock._lastInterface._lastQuestion;
+  assert.strictEqual(secretQuestion._title, 'Enter Yandex Client Secret: ');
+  secretQuestion._answer('my-secret');
+
+  // auth() in manual mode then asks for confirmation code
+  await new Promise(process.nextTick);
+  const codeQuestion = readlineMock._lastInterface._lastQuestion;
+  codeQuestion._answer('sec-code');
+
+  await mainPromise;
+
+  assert.strictEqual(process.exit.mock.callCount(), 0); // success
+  assert.ok(
+    process.stdout.write.mock.calls.some(
+      (call) => typeof call.arguments[0] === 'string' && call.arguments[0].includes('Token obtained successfully')
+    )
+  );
+});
+
+test('main() prompts for mode and redirect-uri when neither flag is set', async () => {
+  const tokenData = { access_token: 'prompt-mode', expires_in: 3600, token_type: 'bearer' };
+  createFetchMock({ body: tokenData });
+
+  const mainPromise = main(['node', 'bin/ya-token-cli.js', '--client-id', 'cid', '--client-secret', 'csecret']);
+
+  // Answer mode: yes to automatic
+  const modeQuestion = readlineMock._lastInterface._lastQuestion;
+  assert.strictEqual(modeQuestion._title, 'Obtain token automatically via redirect? (Y): ');
+  modeQuestion._answer('Y');
+
+  // Wait for next prompt
+  await new Promise(process.nextTick);
+
+  // Answer redirect URI
+  const redirectQuestion = readlineMock._lastInterface._lastQuestion;
+  assert.strictEqual(redirectQuestion._title, 'Enter Redirect URI (http://localhost:8899): ');
+  redirectQuestion._answer('http://localhost:18892');
+
+  // Wait for server to start
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  // Simulate redirect
+  await new Promise((resolve, reject) => {
+    const req = http.request('http://localhost:18892/?code=auto-code', (response) => {
+      response.resume();
+      response.statusCode === 200 ? resolve() : reject(response.statusCode);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+
+  await mainPromise;
+
+  assert.strictEqual(process.exit.mock.callCount(), 0); // success
+});
+
+test('main() prompts for mode — user chooses manual', async () => {
+  const tokenData = { access_token: 'choose-manual', expires_in: 3600, token_type: 'bearer' };
+  createFetchMock({ body: 'https://clck.ru/manual-choice' }); // short URL
+  createFetchMock({ body: tokenData }); // token exchange
+
+  const mainPromise = main([
+    'node',
+    'bin/ya-token-cli.js',
+    '--client-id',
+    'cid',
+    '--client-secret',
+    'csecret',
+    '--short-url'
+  ]);
+
+  // Answer mode: no to automatic → manual
+  const modeQuestion = readlineMock._lastInterface._lastQuestion;
+  assert.strictEqual(modeQuestion._title, 'Obtain token automatically via redirect? (Y): ');
+  modeQuestion._answer('n');
+
+  // Wait for auth() to start and prompt for confirmation code
+  await new Promise(process.nextTick);
+
+  // auth() in manual mode asks for confirmation code
+  const codeQuestion = readlineMock._lastInterface._lastQuestion;
+  assert.strictEqual(codeQuestion._title, 'Enter confirmation code: ');
+  codeQuestion._answer('manual-code');
+
+  await mainPromise;
+
+  assert.strictEqual(process.exit.mock.callCount(), 0); // success
+  assert.ok(
+    process.stdout.write.mock.calls.some(
+      (call) => typeof call.arguments[0] === 'string' && call.arguments[0].includes('Token obtained successfully')
+    )
+  );
+});


### PR DESCRIPTION
Adds a CLI command so users can obtain a Yandex OAuth token via `npx ya-token-cli` or global install.

Changes:
- Add bin/ya-token-cli.js with commander-based arg parsing and interactive prompts
- Support --client-id, --client-secret, --redirect-uri, --manual, --short-url flags
- Add bin entry to package.json and update lint/test scripts for bin files
- Add unit tests for main() covering all flags, env vars, prompts and error cases
- Add commander as a dependency

Closes #133