### PR TITLE
Chore: [#134] Update actions/setup-node to v6.4.0 and coverallsapp/github-action to v2.3.6

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test with node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ matrix.node }}
       - name: Installing dependencies
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 26
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: Test with node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ matrix.node }}
       - name: Installing dependencies
@@ -28,7 +28,7 @@ jobs:
         env:
           YANDEX_CLIENT_ID: ${{ secrets.YANDEX_CLIENT_ID }}
           YANDEX_CLIENT_SECRET: ${{ secrets.YANDEX_CLIENT_SECRET }}
-      - uses: coverallsapp/github-action@v2
+      - uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: node v${{ matrix.node }}
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Publishing coverage report
     steps:
-      - uses: coverallsapp/github-action@v2
+      - uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true


### PR DESCRIPTION
Pin setup-node and coveralls actions to specific versions in both npm-test.yml and npm-publish.yml workflows.

Closes #134