### PR TITLE
Fix: [#135] Change NPM publish trigger from created to published

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,7 @@ name: Publish to NPM
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   test:


### PR DESCRIPTION
Use `published` event type so the workflow also fires when a draft release is published, not just on initial creation.

Closes #135