### PR TITLE
Chore: Clean up .npmignore — exclude .husky, .nvmrc, .pi, eslint.config.js

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,10 +2,14 @@
 .eslintrc
 .gitattributes
 .github
+.husky
+.nvmrc
+.pi
 .prettierrc
 .vscode
 *.tgz
 coverage
+eslint.config.js
 example.js
 node_modules
 specs


### PR DESCRIPTION
Exclude dev-only files from the published npm package:

- `.husky/` — git hooks
- `.nvmrc` — Node version manager config
- `.pi/` — pi coding agent config
- `eslint.config.js` — ESLint configuration

Reduces package size from 28.4 kB → 25.6 kB (12 files vs 18).