### PR TITLE
Fix: Skip prepare script (husky) during npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,4 +42,4 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org/
       - name: Publishing
-        run: npm publish
+        run: npm publish --ignore-scripts


### PR DESCRIPTION
Add `--ignore-scripts` to the publish step to skip the `prepare` script (husky), which isn't needed during publishing and can fail since `.husky` is excluded from the published package.